### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+japanese.table
+list.xlsx
+noise.txt
+readme.txt
+wav/


### PR DESCRIPTION
ダウンロードしたディレクトリを `git init` などでそのまま git repository にした場合、ダウンロードデータのみに含まれる wav ファイルなどが差分として現れてしまうため、 `.gitignore` ファイルを追加しました。今後 git 管理する予定があるなど、意図的に無視していないファイルがあれば修正します。